### PR TITLE
Rewrote multiprocessing parts to only require one database connection

### DIFF
--- a/dejavu/decoder.py
+++ b/dejavu/decoder.py
@@ -43,6 +43,6 @@ def read(filename, limit=None):
 def path_to_songname(path):
     """
     Extracts song name from a filepath. Used to identify which songs
-    have already been fingerprinted on disk. 
+    have already been fingerprinted on disk.
     """
-    return os.path.basename(path).split(".")[0]
+    return os.path.splitext(os.path.basename(path))[0]


### PR DESCRIPTION
List of changes:
- `fingerprint_directory`:
  Now uses `multiprocessing.Pool.imap` and updates database in callers
  process.
- `fingerprint_file`:
  Now uses `_fingerprint_worker` internally.
- `_fingerprint_worker`:
  1. Some slight changes to argument handling due to `imap`
     usage.
  2. Changed to return (song_name, hashes) where hashes is
     a set of hashes from all channels.
- `path_to_songname`:
  Changed to use `os.path.splitext`, this caused files with
  a period in their name to return the wrong name.

These changes should remove some of the blocks @pguridi had while implementing the SQLAlchemy backend.
