### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mp3
 *.mp3
 .DS_Store
 *.cnf
+results*

--- a/dejavu.py
+++ b/dejavu.py
@@ -17,7 +17,7 @@ DEFAULT_CONFIG_FILE = "dejavu.cnf.SAMPLE"
 
 
 def init(configpath):
-    """ 
+    """
     Load config from a JSON file
     """
     try:
@@ -88,6 +88,6 @@ if __name__ == '__main__':
             song = djv.recognize(MicrophoneRecognizer, seconds=opt_arg)
         elif source == 'file':
             song = djv.recognize(FileRecognizer, opt_arg)
-        print(song)
+        print(json.dumps(song))
 
     sys.exit(0)

--- a/dejavu/__init__.py
+++ b/dejavu/__init__.py
@@ -1,11 +1,12 @@
-from dejavu.database import get_database, Database
-import dejavu.decoder as decoder
-import fingerprint
+from __future__ import absolute_import, print_function
 import multiprocessing
 import os
 import traceback
 import sys
 
+from . import fingerprint
+from . import decoder
+from .database import get_database, Database
 
 class Dejavu(object):
 
@@ -58,7 +59,7 @@ class Dejavu(object):
 
             # don't refingerprint already fingerprinted files
             if decoder.unique_hash(filename) in self.songhashes_set:
-                print "%s already fingerprinted, continuing..." % filename
+                print("%s already fingerprinted, continuing..." % filename)
                 continue
 
             filenames_to_fingerprint.append(filename)
@@ -74,7 +75,7 @@ class Dejavu(object):
         # Loop till we have all of them
         while True:
             try:
-                song_name, hashes, file_hash = iterator.next()
+                song_name, hashes, file_hash = next(iterator)
             except multiprocessing.TimeoutError:
                 continue
             except StopIteration:
@@ -99,7 +100,7 @@ class Dejavu(object):
         song_name = song_name or songname
         # don't refingerprint already fingerprinted files
         if song_hash in self.songhashes_set:
-            print "%s already fingerprinted, continuing..." % song_name
+            print("%s already fingerprinted, continuing..." % song_name)
         else:
             song_name, hashes, file_hash = _fingerprint_worker(
                 filepath,

--- a/dejavu/decoder.py
+++ b/dejavu/decoder.py
@@ -1,17 +1,24 @@
 import os
 import fnmatch
+from hashlib import sha1
+
 import numpy as np
 from pydub import AudioSegment
 from pydub.utils import audioop
-import wavio
-from hashlib import sha1
+
+from . import wavio
+
+try:
+    range = xrange
+except NameError:
+    pass
 
 def unique_hash(filepath, blocksize=2**20):
     """ Small function to generate a hash to uniquely generate
     a file. Inspired by MD5 version here:
     http://stackoverflow.com/a/1131255/712997
 
-    Works with large files. 
+    Works with large files.
     """
     s = sha1()
     with open(filepath , "rb") as f:
@@ -56,7 +63,7 @@ def read(filename, limit=None):
         data = np.fromstring(audiofile._data, np.int16)
 
         channels = []
-        for chn in xrange(audiofile.channels):
+        for chn in range(audiofile.channels):
             channels.append(data[chn::audiofile.channels])
 
         fs = audiofile.frame_rate

--- a/dejavu/fingerprint.py
+++ b/dejavu/fingerprint.py
@@ -1,11 +1,13 @@
+from __future__ import absolute_import, print_function
+import hashlib
+from operator import itemgetter
+
 import numpy as np
 import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 from scipy.ndimage.filters import maximum_filter
 from scipy.ndimage.morphology import (generate_binary_structure,
                                       iterate_structure, binary_erosion)
-import hashlib
-from operator import itemgetter
 
 IDX_FREQ_I = 0
 IDX_TIME_J = 1
@@ -127,7 +129,7 @@ def get_2D_peaks(arr2D, plot=False, amp_min=DEFAULT_AMP_MIN):
         plt.gca().invert_yaxis()
         plt.show()
 
-    return zip(frequency_idx, time_idx)
+    return list(zip(frequency_idx, time_idx))
 
 
 def generate_hashes(peaks, fan_value=DEFAULT_FAN_VALUE):
@@ -142,7 +144,7 @@ def generate_hashes(peaks, fan_value=DEFAULT_FAN_VALUE):
     for i in range(len(peaks)):
         for j in range(1, fan_value):
             if (i + j) < len(peaks):
-                
+
                 freq1 = peaks[i][IDX_FREQ_I]
                 freq2 = peaks[i + j][IDX_FREQ_I]
                 t1 = peaks[i][IDX_TIME_J]
@@ -151,5 +153,5 @@ def generate_hashes(peaks, fan_value=DEFAULT_FAN_VALUE):
 
                 if t_delta >= MIN_HASH_TIME_DELTA and t_delta <= MAX_HASH_TIME_DELTA:
                     h = hashlib.sha1(
-                        "%s|%s|%s" % (str(freq1), str(freq2), str(t_delta)))
+                        "|".join((str(freq1), str(freq2), str(t_delta))).encode('utf-8'))
                     yield (h.hexdigest()[0:FINGERPRINT_REDUCTION], t1)

--- a/dejavu/recognize.py
+++ b/dejavu/recognize.py
@@ -1,8 +1,10 @@
-import dejavu.fingerprint as fingerprint
-import dejavu.decoder as decoder
+import time
+
 import numpy as np
 import pyaudio
-import time
+
+from . import fingerprint
+from . import decoder
 
 
 class BaseRecognizer(object):

--- a/dejavu/testing.py
+++ b/dejavu/testing.py
@@ -1,8 +1,4 @@
-from __future__ import division
-from pydub import AudioSegment
-from dejavu.decoder import path_to_songname
-from dejavu import Dejavu
-from dejavu.fingerprint import *
+from __future__ import absolute_import, print_function, division
 import traceback
 import fnmatch
 import os, re, ast
@@ -10,19 +6,25 @@ import subprocess
 import random
 import logging
 
+from pydub import AudioSegment
+
+from . import Dejavu
+from .decoder import path_to_songname
+from .fingerprint import *
+
 def set_seed(seed=None):
     """
-    `seed` as None means that the sampling will be random. 
+    `seed` as None means that the sampling will be random.
 
-    Setting your own seed means that you can produce the 
-    same experiment over and over. 
+    Setting your own seed means that you can produce the
+    same experiment over and over.
     """
     if seed != None:
         random.seed(seed)
 
 def get_files_recursive(src, fmt):
     """
-    `src` is the source directory. 
+    `src` is the source directory.
     `fmt` is the extension, ie ".mp3" or "mp3", etc.
     """
     for root, dirnames, filenames in os.walk(src):
@@ -31,13 +33,13 @@ def get_files_recursive(src, fmt):
 
 def get_length_audio(audiopath, extension):
     """
-    Returns length of audio in seconds. 
-    Returns None if format isn't supported or in case of error. 
+    Returns length of audio in seconds.
+    Returns None if format isn't supported or in case of error.
     """
     try:
         audio = AudioSegment.from_file(audiopath, extension.replace(".", ""))
     except:
-        print "Error in get_length_audio(): %s" % traceback.format_exc()
+        print("Error in get_length_audio(): %s" % traceback.format_exc())
         return None
     return int(len(audio) / 1000.0)
 
@@ -55,13 +57,13 @@ def get_starttime(length, nseconds, padding):
 def generate_test_files(src, dest, nseconds, fmts=[".mp3", ".wav"], padding=10):
     """
     Generates a test file for each file recursively in `src` directory
-    of given format using `nseconds` sampled from the audio file. 
+    of given format using `nseconds` sampled from the audio file.
 
     Results are written to `dest` directory.
 
     `padding` is the number of off-limit seconds and the beginning and
-    end of a track that won't be sampled in testing. Often you want to 
-    avoid silence, etc. 
+    end of a track that won't be sampled in testing. Often you want to
+    avoid silence, etc.
     """
     # create directories if necessary
     for directory in [src, dest]:
@@ -72,23 +74,23 @@ def generate_test_files(src, dest, nseconds, fmts=[".mp3", ".wav"], padding=10):
 
     # find files recursively of a given file format
     for fmt in fmts:
-        testsources = get_files_recursive(src, fmt) 
+        testsources = get_files_recursive(src, fmt)
         for audiosource in testsources:
 
-            print "audiosource:", audiosource
-            
+            print("audiosource:", audiosource)
+
             filename, extension = os.path.splitext(os.path.basename(audiosource))
-            length = get_length_audio(audiosource, extension) 
+            length = get_length_audio(audiosource, extension)
             starttime = get_starttime(length, nseconds, padding)
 
             test_file_name = "%s_%s_%ssec.%s" % (
-                os.path.join(dest, filename), starttime, 
+                os.path.join(dest, filename), starttime,
                 nseconds, extension.replace(".", ""))
-            
+
             subprocess.check_output([
                 "ffmpeg", "-y",
-                "-ss", "%d" % starttime, 
-                '-t' , "%d" % nseconds, 
+                "-ss", "%d" % starttime,
+                '-t' , "%d" % nseconds,
                 "-i", audiosource,
                 test_file_name])
 
@@ -96,20 +98,20 @@ def log_msg(msg, log=True, silent=False):
     if log:
         logging.debug(msg)
     if not silent:
-        print msg
+        print(msg)
 
 def autolabel(rects, ax):
     # attach some text labels
     for rect in rects:
         height = rect.get_height()
-        ax.text(rect.get_x() + rect.get_width() / 2., 1.05 * height, 
+        ax.text(rect.get_x() + rect.get_width() / 2., 1.05 * height,
             '%d' % int(height), ha='center', va='bottom')
 
 def autolabeldoubles(rects, ax):
     # attach some text labels
     for rect in rects:
         height = rect.get_height()
-        ax.text(rect.get_x() + rect.get_width() / 2., 1.05 * height, 
+        ax.text(rect.get_x() + rect.get_width() / 2., 1.05 * height,
             '%s' % round(float(height), 3), ha='center', va='bottom')
 
 class DejavuTest(object):
@@ -120,35 +122,35 @@ class DejavuTest(object):
         self.test_seconds = seconds
         self.test_songs = []
 
-        print "test_seconds", self.test_seconds
+        print("test_seconds", self.test_seconds)
 
         self.test_files = [
-            f for f in os.listdir(self.test_folder) 
-            if os.path.isfile(os.path.join(self.test_folder, f)) 
+            f for f in os.listdir(self.test_folder)
+            if os.path.isfile(os.path.join(self.test_folder, f))
             and re.findall("[0-9]*sec", f)[0] in self.test_seconds]
 
-        print "test_files", self.test_files
+        print("test_files", self.test_files)
 
         self.n_columns = len(self.test_seconds)
         self.n_lines = int(len(self.test_files) / self.n_columns)
 
-        print "columns:", self.n_columns
-        print "length of test files:", len(self.test_files)
-        print "lines:", self.n_lines
+        print("columns:", self.n_columns)
+        print("length of test files:", len(self.test_files))
+        print("lines:", self.n_lines)
 
         # variable match results (yes, no, invalid)
-        self.result_match = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)] 
+        self.result_match = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
 
-        print "result_match matrix:", self.result_match 
+        print("result_match matrix:", self.result_match)
 
         # variable match precision (if matched in the corrected time)
-        self.result_matching_times = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)] 
+        self.result_matching_times = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
 
-        # variable mahing time (query time) 
-        self.result_query_duration = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)] 
+        # variable mahing time (query time)
+        self.result_query_duration = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
 
         # variable confidence
-        self.result_match_confidence = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)] 
+        self.result_match_confidence = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
 
         self.begin()
 
@@ -178,7 +180,7 @@ class DejavuTest(object):
 
             # add some
             ax.set_ylabel(name)
-            ax.set_title("%s %s Results" % (self.test_seconds[sec], name)) 
+            ax.set_title("%s %s Results" % (self.test_seconds[sec], name))
             ax.set_xticks(ind + width)
 
             labels = [0 for x in range(0, self.n_lines)]
@@ -206,16 +208,16 @@ class DejavuTest(object):
             log_msg('--------------------------------------------------')
             log_msg('file: %s' % f)
 
-            # get column 
+            # get column
             col = self.get_column_id(re.findall("[0-9]*sec", f)[0])
             # format: XXXX_offset_length.mp3
-            song = path_to_songname(f).split("_")[0]  
+            song = path_to_songname(f).split("_")[0]
             line = self.get_line_id(song)
             result = subprocess.check_output([
-                "python", 
+                "python",
                 "dejavu.py",
                 '-r',
-                'file', 
+                'file',
                 self.test_folder + "/" + f])
 
             if result.strip() == "None":
@@ -224,7 +226,7 @@ class DejavuTest(object):
                 self.result_matching_times[line][col] = 0
                 self.result_query_duration[line][col] = 0
                 self.result_match_confidence[line][col] = 0
-            
+
             else:
                 result = result.strip()
                 result = result.replace(" \'", ' "')
@@ -246,7 +248,7 @@ class DejavuTest(object):
                     self.result_match_confidence[line][col] = 0
                 else:
                     log_msg('correct match')
-                    print self.result_match
+                    print(self.result_match)
                     self.result_match[line][col] = 'yes'
                     self.result_query_duration[line][col] = round(result[Dejavu.MATCH_TIME],3)
                     self.result_match_confidence[line][col] = result[Dejavu.CONFIDENCE]
@@ -254,7 +256,7 @@ class DejavuTest(object):
                     song_start_time = re.findall("\_[^\_]+",f)
                     song_start_time = song_start_time[0].lstrip("_ ")
 
-                    result_start_time = round((result[Dejavu.OFFSET] * DEFAULT_WINDOW_SIZE * 
+                    result_start_time = round((result[Dejavu.OFFSET] * DEFAULT_WINDOW_SIZE *
                         DEFAULT_OVERLAP_RATIO) / (DEFAULT_FS), 0)
 
                     self.result_matching_times[line][col] = int(result_start_time) - int(song_start_time)

--- a/dejavu/testing.py
+++ b/dejavu/testing.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, print_function, division
 import traceback
 import fnmatch
-import os, re, ast
+import os
+import re
+import json
 import subprocess
 import random
 import logging
@@ -11,6 +13,11 @@ from pydub import AudioSegment
 from . import Dejavu
 from .decoder import path_to_songname
 from .fingerprint import *
+
+try:
+    range = xrange
+except NameError:
+    pass
 
 def set_seed(seed=None):
     """
@@ -139,18 +146,18 @@ class DejavuTest(object):
         print("lines:", self.n_lines)
 
         # variable match results (yes, no, invalid)
-        self.result_match = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
+        self.result_match = [[0 for x in range(self.n_columns)] for x in range(self.n_lines)]
 
         print("result_match matrix:", self.result_match)
 
         # variable match precision (if matched in the corrected time)
-        self.result_matching_times = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
+        self.result_matching_times = [[0 for x in range(self.n_columns)] for x in range(self.n_lines)]
 
         # variable mahing time (query time)
-        self.result_query_duration = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
+        self.result_query_duration = [[0 for x in range(self.n_columns)] for x in range(self.n_lines)]
 
         # variable confidence
-        self.result_match_confidence = [[0 for x in xrange(self.n_columns)] for x in xrange(self.n_lines)]
+        self.result_match_confidence = [[0 for x in range(self.n_columns)] for x in range(self.n_lines)]
 
         self.begin()
 
@@ -218,9 +225,10 @@ class DejavuTest(object):
                 "dejavu.py",
                 '-r',
                 'file',
-                self.test_folder + "/" + f])
+                self.test_folder + "/" + f],
+                universal_newlines=True)
 
-            if result.strip() == "None":
+            if result.strip() == "null":
                 log_msg('No match')
                 self.result_match[line][col] = 'no'
                 self.result_matching_times[line][col] = 0
@@ -228,14 +236,8 @@ class DejavuTest(object):
                 self.result_match_confidence[line][col] = 0
 
             else:
-                result = result.strip()
-                result = result.replace(" \'", ' "')
-                result = result.replace("{\'", '{"')
-                result = result.replace("\':", '":')
-                result = result.replace("\',", '",')
-
                 # which song did we predict?
-                result = ast.literal_eval(result)
+                result = json.loads(result)
                 song_result = result["song_name"]
                 log_msg('song: %s' % song)
                 log_msg('song_result: %s' % song_result)

--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import warnings
 import json
 warnings.filterwarnings("ignore")
@@ -19,17 +20,17 @@ if __name__ == '__main__':
 
 	# Recognize audio from a file
 	song = djv.recognize(FileRecognizer, "mp3/Sean-Fournier--Falling-For-You.mp3")
-	print "From file we recognized: %s\n" % song
+	print("From file we recognized: %s\n" % song)
 
 	# Or recognize audio from your microphone for `secs` seconds
 	secs = 5
 	song = djv.recognize(MicrophoneRecognizer, seconds=secs)
 	if song is None:
-		print "Nothing recognized -- did you play the song out loud so your mic could hear it? :)"
+		print("Nothing recognized -- did you play the song out loud so your mic could hear it? :)")
 	else:
-		print "From mic with %d seconds we recognized: %s\n" % (secs, song)
+		print("From mic with %d seconds we recognized: %s\n" % (secs, song))
 
 	# Or use a recognizer without the shortcut, in anyway you would like
 	recognizer = FileRecognizer(djv)
 	song = recognizer.recognize_file("mp3/Josh-Woodward--I-Want-To-Destroy-Something-Beautiful.mp3")
-	print "No shortcut, we recognized: %s\n" % song
+	print("No shortcut, we recognized: %s\n" % song)

--- a/example.py
+++ b/example.py
@@ -12,25 +12,25 @@ with open("dejavu.cnf.SAMPLE") as f:
 
 if __name__ == '__main__':
 
-	# create a Dejavu instance
-	djv = Dejavu(config)
+    # create a Dejavu instance
+    djv = Dejavu(config)
 
-	# Fingerprint all the mp3's in the directory we give it
-	djv.fingerprint_directory("mp3", [".mp3"])
+    # Fingerprint all the mp3's in the directory we give it
+    djv.fingerprint_directory("mp3", [".mp3"])
 
-	# Recognize audio from a file
-	song = djv.recognize(FileRecognizer, "mp3/Sean-Fournier--Falling-For-You.mp3")
-	print("From file we recognized: %s\n" % song)
+    # Recognize audio from a file
+    song = djv.recognize(FileRecognizer, "mp3/Sean-Fournier--Falling-For-You.mp3")
+    print("From file we recognized: %s\n" % song)
 
-	# Or recognize audio from your microphone for `secs` seconds
-	secs = 5
-	song = djv.recognize(MicrophoneRecognizer, seconds=secs)
-	if song is None:
-		print("Nothing recognized -- did you play the song out loud so your mic could hear it? :)")
-	else:
-		print("From mic with %d seconds we recognized: %s\n" % (secs, song))
+    # Or recognize audio from your microphone for `secs` seconds
+    secs = 5
+    song = djv.recognize(MicrophoneRecognizer, seconds=secs)
+    if song is None:
+        print("Nothing recognized -- did you play the song out loud so your mic could hear it? :)")
+    else:
+        print("From mic with %d seconds we recognized: %s\n" % (secs, song))
 
-	# Or use a recognizer without the shortcut, in anyway you would like
-	recognizer = FileRecognizer(djv)
-	song = recognizer.recognize_file("mp3/Josh-Woodward--I-Want-To-Destroy-Something-Beautiful.mp3")
-	print("No shortcut, we recognized: %s\n" % song)
+    # Or use a recognizer without the shortcut, in anyway you would like
+    recognizer = FileRecognizer(djv)
+    song = recognizer.recognize_file("mp3/Josh-Woodward--I-Want-To-Destroy-Something-Beautiful.mp3")
+    print("No shortcut, we recognized: %s\n" % song)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,9 +1,16 @@
+from optparse import OptionParser
+import shutil
+import time
+
+import matplotlib.pyplot as plt
+
 from dejavu.testing import *
 from dejavu import Dejavu
-from optparse import OptionParser
-import matplotlib.pyplot as plt
-import time
-import shutil
+
+try:
+    range = xrange
+except NameError:
+    pass
 
 usage = "usage: %prog [options] TESTING_AUDIOFOLDER"
 parser = OptionParser(usage=usage, version="%prog 1.1")
@@ -61,7 +68,7 @@ try:
 except:
     os.mkdir(options.results_folder)
 
-# set logging 
+# set logging
 if options.log:
     logging.basicConfig(filename=options.log_file, level=logging.DEBUG)
 
@@ -70,11 +77,11 @@ test_seconds = ['%dsec' % i for i in range(1, options.secs + 1, 1)]
 
 # generate testing files
 for i in range(1, options.secs + 1, 1):
-    generate_test_files(test_folder, options.temp_folder, 
+    generate_test_files(test_folder, options.temp_folder,
                         i, padding=options.padding)
 
 # scan files
-log_msg("Running Dejavu fingerprinter on files in %s..." % test_folder, 
+log_msg("Running Dejavu fingerprinter on files in %s..." % test_folder,
         log=options.log, silent=options.silent)
 
 tm = time.time()
@@ -83,102 +90,102 @@ log_msg("finished obtaining results from dejavu in %s" % (time.time() - tm),
         log=options.log, silent=options.silent)
 
 tests = 1  # djv
-n_secs = len(test_seconds) 
+n_secs = len(test_seconds)
 
 # set result variables -> 4d variables
-all_match_counter = [[[0 for x in xrange(tests)] for x in xrange(3)] for x in xrange(n_secs)]
-all_matching_times_counter = [[[0 for x in xrange(tests)] for x in xrange(2)] for x in xrange(n_secs)]
-all_query_duration = [[[0 for x in xrange(tests)] for x in xrange(djv.n_lines)] for x in xrange(n_secs)]
-all_match_confidence = [[[0 for x in xrange(tests)] for x in xrange(djv.n_lines)] for x in xrange(n_secs)]
+all_match_counter = [[[0 for x in range(tests)] for x in range(3)] for x in range(n_secs)]
+all_matching_times_counter = [[[0 for x in range(tests)] for x in range(2)] for x in range(n_secs)]
+all_query_duration = [[[0 for x in range(tests)] for x in range(djv.n_lines)] for x in range(n_secs)]
+all_match_confidence = [[[0 for x in range(tests)] for x in range(djv.n_lines)] for x in range(n_secs)]
 
 # group results by seconds
 for line in range(0, djv.n_lines):
-	for col in range(0, djv.n_columns):
-		# for dejavu
-		all_query_duration[col][line][0] = djv.result_query_duration[line][col]
-		all_match_confidence[col][line][0] = djv.result_match_confidence[line][col]
+    for col in range(0, djv.n_columns):
+        # for dejavu
+        all_query_duration[col][line][0] = djv.result_query_duration[line][col]
+        all_match_confidence[col][line][0] = djv.result_match_confidence[line][col]
 
-		djv_match_result = djv.result_match[line][col]
+        djv_match_result = djv.result_match[line][col]
 
-		if djv_match_result == 'yes':
-			all_match_counter[col][0][0] += 1
-		elif djv_match_result == 'no':
-			all_match_counter[col][1][0] += 1
-		else:
-			all_match_counter[col][2][0] += 1
+        if djv_match_result == 'yes':
+            all_match_counter[col][0][0] += 1
+        elif djv_match_result == 'no':
+            all_match_counter[col][1][0] += 1
+        else:
+            all_match_counter[col][2][0] += 1
 
-		djv_match_acc = djv.result_matching_times[line][col]
+        djv_match_acc = djv.result_matching_times[line][col]
 
-		if djv_match_acc == 0 and djv_match_result == 'yes':
-			all_matching_times_counter[col][0][0] += 1
-		elif djv_match_acc != 0:
-			all_matching_times_counter[col][1][0] += 1
+        if djv_match_acc == 0 and djv_match_result == 'yes':
+            all_matching_times_counter[col][0][0] += 1
+        elif djv_match_acc != 0:
+            all_matching_times_counter[col][1][0] += 1
 
 # create plots
 djv.create_plots('Confidence', all_match_confidence, options.results_folder)
 djv.create_plots('Query duration', all_query_duration, options.results_folder)
 
 for sec in range(0, n_secs):
-	ind = np.arange(3) #
-	width = 0.25       # the width of the bars
+    ind = np.arange(3) #
+    width = 0.25       # the width of the bars
 
-	fig = plt.figure()
-	ax = fig.add_subplot(111)
-	ax.set_xlim([-1 * width, 2.75])
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.set_xlim([-1 * width, 2.75])
 
-	means_dvj = [round(x[0] * 100 / djv.n_lines, 1) for x in all_match_counter[sec]]
-	rects1 = ax.bar(ind, means_dvj, width, color='r')
+    means_dvj = [round(x[0] * 100 / djv.n_lines, 1) for x in all_match_counter[sec]]
+    rects1 = ax.bar(ind, means_dvj, width, color='r')
 
-	# add some
-	ax.set_ylabel('Matching Percentage')
-	ax.set_title('%s Matching Percentage' % test_seconds[sec])
-	ax.set_xticks(ind + width)
+    # add some
+    ax.set_ylabel('Matching Percentage')
+    ax.set_title('%s Matching Percentage' % test_seconds[sec])
+    ax.set_xticks(ind + width)
 
-	labels = ['yes','no','invalid']
-	ax.set_xticklabels( labels )
+    labels = ['yes','no','invalid']
+    ax.set_xticklabels( labels )
 
-	box = ax.get_position()
-	ax.set_position([box.x0, box.y0, box.width * 0.75, box.height])
-	#ax.legend((rects1[0]), ('Dejavu'), loc='center left', bbox_to_anchor=(1, 0.5))
-	autolabeldoubles(rects1,ax)
-	plt.grid()
+    box = ax.get_position()
+    ax.set_position([box.x0, box.y0, box.width * 0.75, box.height])
+    #ax.legend((rects1[0]), ('Dejavu'), loc='center left', bbox_to_anchor=(1, 0.5))
+    autolabeldoubles(rects1,ax)
+    plt.grid()
 
- 	fig_name = os.path.join(options.results_folder, "matching_perc_%s.png" % test_seconds[sec])
- 	fig.savefig(fig_name)
+    fig_name = os.path.join(options.results_folder, "matching_perc_%s.png" % test_seconds[sec])
+    fig.savefig(fig_name)
 
 for sec in range(0, n_secs):
-	ind = np.arange(2) #
-	width = 0.25       # the width of the bars
+    ind = np.arange(2) #
+    width = 0.25       # the width of the bars
 
-	fig = plt.figure()
-	ax = fig.add_subplot(111)
-	ax.set_xlim([-1*width, 1.75])
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.set_xlim([-1*width, 1.75])
 
-	div = all_match_counter[sec][0][0]
-	if div == 0 :
-		div = 1000000
+    div = all_match_counter[sec][0][0]
+    if div == 0 :
+        div = 1000000
 
-	means_dvj = [round(x[0] * 100 / div, 1) for x in all_matching_times_counter[sec]]
-	rects1 = ax.bar(ind, means_dvj, width, color='r')
+    means_dvj = [round(x[0] * 100 / div, 1) for x in all_matching_times_counter[sec]]
+    rects1 = ax.bar(ind, means_dvj, width, color='r')
 
-	# add some
-	ax.set_ylabel('Matching Accuracy')
-	ax.set_title('%s Matching Times Accuracy' % test_seconds[sec])
-	ax.set_xticks(ind + width)
+    # add some
+    ax.set_ylabel('Matching Accuracy')
+    ax.set_title('%s Matching Times Accuracy' % test_seconds[sec])
+    ax.set_xticks(ind + width)
 
-	labels = ['yes','no']
-	ax.set_xticklabels( labels )
+    labels = ['yes','no']
+    ax.set_xticklabels( labels )
 
-	box = ax.get_position()
-	ax.set_position([box.x0, box.y0, box.width * 0.75, box.height])
+    box = ax.get_position()
+    ax.set_position([box.x0, box.y0, box.width * 0.75, box.height])
 
-	#ax.legend( (rects1[0]), ('Dejavu'), loc='center left', bbox_to_anchor=(1, 0.5))
-	autolabeldoubles(rects1,ax)
+    #ax.legend( (rects1[0]), ('Dejavu'), loc='center left', bbox_to_anchor=(1, 0.5))
+    autolabeldoubles(rects1,ax)
 
-	plt.grid()
+    plt.grid()
 
- 	fig_name = os.path.join(options.results_folder, "matching_acc_%s.png" % test_seconds[sec])
- 	fig.savefig(fig_name)
+    fig_name = os.path.join(options.results_folder, "matching_acc_%s.png" % test_seconds[sec])
+    fig.savefig(fig_name)
 
 # remove temporary folder
 shutil.rmtree(options.temp_folder)


### PR DESCRIPTION
A bit slap-dash, but nothing major modified. Tweaks generally break down into 4 categories:
1. `print()`
2. Builtin/library generator wrangling (`xrange`, `izip`, forcing generator evaluation...)
3. Explicit relative imports (along with cleaning up imports I generally sorted them into stdlib vs. other)
4. Removing spaces at end of lines (because my editor does it automatically)

Another minor tweak was explicitly encoding a string (unicode in Python 3) into UTF-8 so it could be hashed. 

With the changes, running `example.py` works just fine, but let me know if you want the commits cleaned up a bit.
