### PR TITLE
resolves the infinite loop issue when recognizing song through a micr…

### DIFF
--- a/dejavu.py
+++ b/dejavu.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
         opt_arg = args.recognize[1]
 
         if source in ('mic', 'microphone'):
-            song = djv.recognize(MicrophoneRecognizer, seconds=opt_arg)
+            song = djv.recognize(MicrophoneRecognizer, seconds=int(opt_arg))
         elif source == 'file':
             song = djv.recognize(FileRecognizer, opt_arg)
         print(song)


### PR DESCRIPTION
Executing "python dejavu.py --recognize mic 10" causes script to fall into a very long  loop or a   memory  error because the argument for time (10 in this case) is passed as string to djv.recognize() function. Inside this function this string argument causes either  a very long loop or a memory  error. Casting time argument to integer solves the issue.   