### PR TITLE
Added Dockerfile so dejavu can be ran through a docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM fedora
+MAINTAINER Ravel Antunes
+
+#Add repositores for ffmpeg                                                     
+RUN rpm -ivh http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-stable.noarch.rpm \
+ 	&& rpm -ivh http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-stable.noarch.rpm \
+	&& rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-*       
+
+RUN yum update -y; yum clean all                                                                                                         
+RUN yum -y install numpy scipy python-matplotlib portaudio-devel ffmpeg python python-pip gcc MySQL-python       
+
+RUN pip install virtualenv
+RUN virtualenv --system-site-packages env_with_system
+
+RUN source env_with_system/bin/activate
+RUN pip install https://github.com/worldveil/dejavu/zipball/master
+
+
+RUN mkdir app
+ADD . /app      
+
+
+
+                                                                                 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Read [INSTALLATION.md](INSTALLATION.md)
 
 Alternatively, you can build a docker image from the Dockerfile included:
 	          
-```bash
+```bash  
+$ git clone https://github.com/worldveil/dejavu.git
 $ docker build -t dejavu .
 ```
 	                                        

--- a/README.md
+++ b/README.md
@@ -10,7 +10,28 @@ Note that for voice recognition, Dejavu is not the right tool! Dejavu excels at 
 
 ## Installation and Dependencies:
 
-Read [INSTALLATION.md](INSTALLATION.md)
+Read [INSTALLATION.md](INSTALLATION.md)         
+
+### Docker
+
+Alternatively, you can build a docker image from the Dockerfile included:
+	          
+```bash
+$ docker build -t dejavu .
+```
+	                                        
+And run a container from that image:
+    
+```bash
+$ run -it dejavu /bin/bash
+```
+
+Inside the container, you can find the app inside /app:
+
+```bash
+$ cd /app
+$ python example.py
+```      
 
 ## Setup
 


### PR DESCRIPTION
Added a Dockerfile to make it simpler to setup an environment with dejavu and all it's dependencies through docker. It also eliminates any complexity on getting it running on different OS versions. The docker image is built on top of a Fedora 22 image.
