### PR TITLE
Rejiggered imports to require fewer third-party libraries if certain features aren't used

### DIFF
--- a/dejavu/database.py
+++ b/dejavu/database.py
@@ -172,5 +172,8 @@ def get_database(database_type=None):
     raise TypeError("Unsupported database type supplied.")
 
 
-# Import our default database handler
-import dejavu.database_sql
+# Attempt to import our default database handler
+try:
+    import dejavu.database_sql
+except ImportError:
+    pass


### PR DESCRIPTION
I am trying to use this library for fuzzy audio comparison in a limited environment where it is ideal to use as few third-party libraries as possible. Since this library only uses pydub for audio decoding, and only uses mysql if you use the mysql database, and I only need to use wav files and created my own memory backed database, I modified the library to not require those libraries if you do not want to use those features, which I imagine could be a fairly common occurrence.

I also fixed a bug that would cause an exception if you loaded a 24-bit wav file, because it would have audiofile be a numpy array, instead of an AudioSegment, and so would be unable to get `audiofile.frame_rate`. Replaced with `fs`, which appears to have been created for this purpose.