### PR TITLE
Optimize maximum filter

### DIFF
--- a/dejavu/fingerprint.py
+++ b/dejavu/fingerprint.py
@@ -1,7 +1,7 @@
 import numpy as np
 import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
-from scipy.ndimage.filters import maximum_filter
+from scipy.ndimage.filters import maximum_filter1d
 from scipy.ndimage.morphology import (generate_binary_structure,
                                       iterate_structure, binary_erosion)
 import hashlib
@@ -93,9 +93,10 @@ def get_2D_peaks(arr2D, plot=False, amp_min=DEFAULT_AMP_MIN):
     #  http://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.iterate_structure.html#scipy.ndimage.iterate_structure
     struct = generate_binary_structure(2, 1)
     neighborhood = iterate_structure(struct, PEAK_NEIGHBORHOOD_SIZE)
-
     # find local maxima using our filter shape
-    local_max = maximum_filter(arr2D, footprint=neighborhood) == arr2D
+    local_max = maximum_filter1d(arr2D, size=PEAK_NEIGHBORHOOD_SIZE*2+1, axis=0)
+    local_max = maximum_filter1d(local_max, size=PEAK_NEIGHBORHOOD_SIZE*2+1, axis=1)
+    local_max = local_max == arr2D
     background = (arr2D == 0)
     eroded_background = binary_erosion(background, structure=neighborhood,
                                        border_value=1)


### PR DESCRIPTION
The line: https://github.com/worldveil/dejavu/blob/d2b8761eb39f8e2479503f936e9f9948addea8ea/dejavu/fingerprint.py#L98 is taking up around 80% of processing time (my feeling), which makes it a bottleneck in processing.

The maximum filter loops over all positions, takes the maximum of all numbers in a diamond-like area centered at the position. The time complexity of the naive implementation is O(N*M*W^2), where N is number of windows, M is number of frequency ranges, and W is window size (PEAK_NEIGHBORHOOD_SIZE=20).

Using a data structure known as monotonic queue, it should be possible to reduce the time complexity down to linear time, which is O(N*M), dividing processing time by up to 400.

The algorithm has been implemented in scipy as `scipy.ndimage.filters.maximum_filter1d`. By applying such an algorithm twice, on the X axis and then on the Y axis, we can get the rectangle maximum. The drawback is that the filter is similar but different from the original one, and the impact on accuracy is unknown. It is technically possible to compute the original maximum filter in linear time but it's harder to implement.

A simple benchmark shows that the time to scan all 5 files in the mp3 folder r**educed from 2m55s to only 40s**, a 4.5x improvement. Note that the number of fingerprints reduced from 494217 to 353834 due to a differnet maximum filter, and the impact is unknown. I expect some more improvement by removing the binary erosion, but on my machine it seems that the bottleneck has already moved from Python to MySQL. For indexing purposes it might be better to use an embedded database, such as RocksDB, to fully squeeze performance.
