### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The algorithm works off a fingerprint based system, much like:
 
 The "fingerprints" are locality sensitive hashes that are computed from the spectrogram of the audio. This is done by taking the FFT of the signal over overlapping windows of the song and identifying peaks. A very robust peak finding algorithm is needed, otherwise you'll have a terrible signal to noise ratio.
 
-Here I've taken the spectrogram over the first few seconds of "Blurred Lines". The spectrogram is a 2D plot and shows amplitude as a function of time (a particular window, actually) and frequency, binned logrithmically, just as the human ear percieves it. In the plot below you can see where local maxima occur in the amplitude space:
+Here I've taken the spectrogram over the first few seconds of "Blurred Lines". The spectrogram is a 2D plot and shows amplitude as a function of time (a particular window, actually) and frequency, binned logrithmically, just as the human ear perceives it. In the plot below you can see where local maxima occur in the amplitude space:
 
 ![Spectrogram](plots/spectrogram_peaks.png)
 

--- a/dejavu/third_party/wavio.py
+++ b/dejavu/third_party/wavio.py
@@ -142,7 +142,7 @@ def read(file):
                 sampwidth is 3.
     Notes
     -----
-    This function uses the `wave` module of the Python standard libary
+    This function uses the `wave` module of the Python standard library
     to read the WAV file, so it has the same limitations as that library.
     In particular, the function does not read compressed WAV files, and
     it does not read files with floating point data.


### PR DESCRIPTION
There are small typos in:
- README.md
- dejavu/third_party/wavio.py

Fixes:
- Should read `perceives` rather than `percieves`.
- Should read `library` rather than `libary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md