### PR TITLE
Performance Tweaks, Iterators, and Lazy Evaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,3 @@ mp3
 *.mp3
 .DS_Store
 *.cnf
-
-# To be restored later
-__pycache__/
-.ruff_cache/
-[._]*.s[a-v][a-z]
-!*.svg  # comment out if you don't need vector files
-[._]*.sw[a-p]
-[._]s[a-rt-v][a-z]
-[._]ss[a-gi-z]
-[._]sw[a-p]
-[._]*.un~

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,14 @@ mp3
 *.mp3
 .DS_Store
 *.cnf
+
+# To be restored later
+__pycache__/
+.ruff_cache/
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+[._]*.un~

--- a/dejavu/__init__.py
+++ b/dejavu/__init__.py
@@ -173,9 +173,9 @@ class Dejavu:
         """
         # count offset occurrences per song and keep only the maximum ones.
         sorted_matches = sorted(matches, key=lambda m: (m[0], m[1]))
-        counts = [(*key, len(list(group))) for key, group in groupby(sorted_matches, key=lambda m: (m[0], m[1]))]
+        counts = ((*key, len(list(group))) for key, group in groupby(sorted_matches, key=lambda m: (m[0], m[1])))
         songs_matches = sorted(
-            [max(list(group), key=lambda g: g[2]) for key, group in groupby(counts, key=lambda count: count[0])],
+            (max(group, key=lambda g: g[2]) for key, group in groupby(counts, key=lambda count: count[0])),
             key=lambda count: count[2], reverse=True
         )
 

--- a/dejavu/__init__.py
+++ b/dejavu/__init__.py
@@ -33,6 +33,8 @@ class Dejavu:
         self.limit = self.config.get("fingerprint_limit", None)
         if self.limit == -1:  # for JSON compatibility
             self.limit = None
+        self.songs = None
+        self.songhashes_set = set()  # to know which ones we've computed before
         self.__load_fingerprinted_audio_hashes()
 
     def __load_fingerprinted_audio_hashes(self) -> None:

--- a/dejavu/__init__.py
+++ b/dejavu/__init__.py
@@ -46,8 +46,7 @@ class Dejavu:
         self.songs = self.db.get_songs()
         self.songhashes_set = set()  # to know which ones we've computed before
         for song in self.songs:
-            song_hash = song[FIELD_FILE_SHA1]
-            self.songhashes_set.add(song_hash)
+            self.songhashes_set.add(song[FIELD_FILE_SHA1])
 
     def get_fingerprinted_songs(self) -> List[Dict[str, any]]:
         """

--- a/dejavu/logic/decoder.py
+++ b/dejavu/logic/decoder.py
@@ -95,9 +95,9 @@ def read(file_name: str, limit: int = None) -> Tuple[List[List[int]], int, str]:
 
         data = np.fromstring(audiofile.raw_data, np.int16)
 
-        channels = []
-        for chn in range(audiofile.channels):
-            channels.append(data[chn::audiofile.channels])
+        channels = [
+            data[chn::audiofile.channels] for chn in range(audiofile.channels)
+        ]
 
         audiofile.frame_rate
     except audioop.error:
@@ -109,9 +109,7 @@ def read(file_name: str, limit: int = None) -> Tuple[List[List[int]], int, str]:
         audiofile = audiofile.T
         audiofile = audiofile.astype(np.int16)
 
-        channels = []
-        for chn in audiofile:
-            channels.append(chn)
+        channels = [chn for chn in audiofile]
 
     return channels, audiofile.frame_rate, unique_hash(file_name)
 

--- a/dejavu/logic/decoder.py
+++ b/dejavu/logic/decoder.py
@@ -23,10 +23,7 @@ def unique_hash(file_path: str, block_size: int = 2**20) -> str:
     """
     s = sha1()
     with open(file_path, "rb") as f:
-        while True:
-            buf = f.read(block_size)
-            if not buf:
-                break
+        while buf := f.read(block_size)
             s.update(buf)
     return s.hexdigest().upper()
 

--- a/dejavu/logic/decoder.py
+++ b/dejavu/logic/decoder.py
@@ -1,7 +1,7 @@
 import fnmatch
 import os
 from hashlib import sha1
-from typing import List, Tuple
+from typing import Generator, List, Tuple
 
 import numpy as np
 from pydub import AudioSegment
@@ -23,7 +23,7 @@ def unique_hash(file_path: str, block_size: int = 2**20) -> str:
     """
     s = sha1()
     with open(file_path, "rb") as f:
-        while buf := f.read(block_size)
+        while buf := f.read(block_size):
             s.update(buf)
     return s.hexdigest().upper()
 
@@ -46,6 +46,30 @@ def find_files(path: str, extensions: List[str]) -> List[Tuple[str, str]]:
                 p = os.path.join(dirpath, f)
                 results.append((p, extension))
     return results
+
+
+def find_files_g(path: str, extensions: List[str]) -> Generator[Tuple[str, str]]:
+    """
+    Get all files that meet the specified extensions.
+
+    :param path: path to a directory with audio files.
+    :param extensions: file extensions to look for.
+    :yields: a tuple with file name and its extension.
+    """
+    # Allow both with ".mp3" and without "mp3" to be used for extensions
+    norm_extensions = set()
+    for extension in extensions:
+        extension = extension.lower()
+        norm_extensions.add(extension)
+        if extension.startswith('.'):
+            norm_extensions.add(extension.lstrip('.'))
+        else:
+            norm_extensions.add(f'.{extension}')
+    for root, dirs, files in os.walk(path):
+        for f in files:
+            ext = os.path.splitext(f)[1].lower()
+            if ext in norm_extensions:
+                yield os.path.join(root, f), ext
 
 
 def read(file_name: str, limit: int = None) -> Tuple[List[List[int]], int, str]:

--- a/dejavu/logic/decoder.py
+++ b/dejavu/logic/decoder.py
@@ -48,7 +48,7 @@ def find_files(path: str, extensions: List[str]) -> List[Tuple[str, str]]:
     return results
 
 
-def find_files_g(path: str, extensions: List[str]) -> Generator[Tuple[str, str]]:
+def find_files_g(path: str, extensions: List[str]) -> Generator[Tuple[str, str], None, None]:
     """
     Get all files that meet the specified extensions.
 


### PR DESCRIPTION
A new function, `dejavu.logic.decoder.find_files_g`, has been created as an iterator replacement for `find_files` in the same file. This allows the updated `Dejavu.fingerprint_directory` method to utilize the `concurrent.futures.ProcessPoolExecutor` in conjunction with the `concurrent.futures.as_completed` function to submit files to be processed as they are yielded for immediate processing. Once all of the files have been submitted to the executor for processing, their respective results will be iterated over in `as_completed`...as they are completed.

These two modifications will allow considerable speed improvements over the existing methods. If anyone knows of where to find a large number of Creative Common openly licensed audio files to download and test on, I would be glad to post comparison results. I tried finding some today but every website was either broken, required creating accounts, or was so extensively rate-limited to be near useless.

Other minor improvements are

- Adding placeholder `songs` and `songhashes_set` in the `__init__` of `Dejavu` to take advantage of `__init__`'s special dict
- Changing `counts` and `songs_matches` in `Dejavu.align_matches` to generator comprehensions
- Adding `song_hash` directly to `self.songhashes_set` instead of creating the variable first. Saves a lookup per iteration
- Waiting to call `Dejavu.__load_fingerprinted_audio_hashes()` until after all files have been processed
- Changing both `channels` in `dejavu.logic.decoder.read` to use list comprehensions